### PR TITLE
With new engine, dimnames() parser issue

### DIFF
--- a/R/lotri.R
+++ b/R/lotri.R
@@ -364,7 +364,7 @@ NULL
 #' @return Returns `TRUE` if the processing is successful and the data
 #'   frame is updated, otherwise returns `FALSE`.
 #' @noRd
-.handleSingleLineEstInForm2 <- function(x2, values, fixed, unfixed, env) {
+.handleSingleLineEstInLineForm <- function(x2, values, fixed, unfixed, env) {
   .r <- values
   .rf <- fixed
   .ru <- unfixed
@@ -425,7 +425,7 @@ NULL
   .r <- .rl[[1]]
   .rf <- .rl[[2]]
   .ru <- .rl[[3]]
-  if (.handleSingleLineEstInForm2(x2, values=.r, fixed=.rf, unfixed=.ru, env)) {
+  if (.handleSingleLineEstInLineForm(x2, values=.r, fixed=.rf, unfixed=.ru, env)) {
     return(NULL)
   }
   if (env$lastN != 0 && length(x2) == 1L && length(.r) == env$lastN + 1) {

--- a/tests/testthat/test-line-form.R
+++ b/tests/testthat/test-line-form.R
@@ -271,4 +271,32 @@ test_that("lotri lower triangular matrix specification 2", {
 
   expect_equal(fix1, fix2)
 
+  test_that("Issue #28", {
+
+    expect_equal(lotri({
+      eta1 ~ 0.175278
+      eta2 ~ c(0.115896, 0.112362)
+      eta3 ~ c(0)
+    }),
+    lotri(eta1+eta2 ~ c(0.175278, 0.115896, 0.112362),
+          eta3 ~  0))
+
+    expect_equal(lotri({
+      eta1 ~ 0.175278
+      eta2 ~ c(0.115896, 0.112362)
+      eta3 ~ fix(0)
+    }),
+    lotri(eta1+eta2 ~ c(0.175278, 0.115896, 0.112362),
+          eta3 ~  fix(0)))
+
+    expect_equal(lotri({
+      eta1 ~ 0.175278
+      eta2 ~ c(0.115896, 0.112362)
+      eta3 ~ 0
+    }),
+    lotri(eta1+eta2 ~ c(0.175278, 0.115896, 0.112362),
+          eta3 ~ 0))
+
+  })
+
 })

--- a/tests/testthat/test-line-form.R
+++ b/tests/testthat/test-line-form.R
@@ -284,10 +284,26 @@ test_that("lotri lower triangular matrix specification 2", {
     expect_equal(lotri({
       eta1 ~ 0.175278
       eta2 ~ c(0.115896, 0.112362)
+      eta3 ~ c(eta3=0)
+    }),
+    lotri(eta1+eta2 ~ c(0.175278, 0.115896, 0.112362),
+          eta3 ~  0))
+
+    expect_equal(lotri({
+      eta1 ~ 0.175278
+      eta2 ~ c(0.115896, 0.112362)
       eta3 ~ fix(0)
     }),
     lotri(eta1+eta2 ~ c(0.175278, 0.115896, 0.112362),
           eta3 ~  fix(0)))
+
+    expect_equal(lotri({
+      eta1 ~ 0.175278
+      eta2 ~ c(0.115896, 0.112362)
+      eta3 ~ fix(0)
+    }),
+    lotri(eta1+eta2 ~ c(0.175278, 0.115896, 0.112362),
+          eta3 ~  fix(eta3=0)))
 
     expect_equal(lotri({
       eta1 ~ 0.175278


### PR DESCRIPTION
``` r
lotri::lotri({
  theta1 <- c(0, 6.20684)
  label("1. TVCL (lower bound,initial estimate)")
  theta2 <- c(0, 26.5004)
  label("2. TVV1  (lower bound,initial estimate)")
  theta3 <- c(0, 2.15099)
  label("3. TVQ")
  theta4 <- c(0, 21.151)
  label("4. TVV2")
  theta5 <- c(0, 0.270697)
  label("5. TVQ2")
  theta6 <- c(0, 147.893)
  label("6. TVV3")
  theta7 <- fix(55.4)
  label("7. T50")
  theta8 <- fix(3.33)
  label("8. Hill")
  theta9 <- -0.129934
  label("9. power exponent on creatinine")
  theta10 <- c(0, 1.70302)
  label("10. PNA50")
  eta1 ~ 0.175278
  eta2 ~ c(0.115896, 0.112362)
  eta3 ~ fix(0)
  eta4 ~ 0.131759
  eta5 ~ fix(0)
  eta6 ~ 0.177214
  eta7 ~ 0.0140684
  eta8 ~ fix(0.0140684)
  eta9 ~ fix(0.0140684)
  eta10 ~ fix(0.0140684)
  eta11 ~ fix(0.0140684)
  eta12 ~ fix(0.0140684)
  eta13 ~ fix(0.0140684)
  eta14 ~ fix(0.0140684)
  eta15 ~ fix(0.0140684)
  eta16 ~ fix(0.0140684)
  eta17 ~ fix(0.0140684)
  eta18 ~ fix(0.0140684)
  eta19 ~ fix(0.0140684)
  eta20 ~ fix(0.0140684)
  eta21 ~ fix(0.0140684)
  eta22 ~ fix(0.0140684)
  eta23 ~ fix(0.0140684)
  eta24 ~ fix(0.0140684)
  eta25 ~ fix(0.0140684)
  eta26 ~ fix(0.0140684)
  eta27 ~ fix(0.0140684)
  eta28 ~ fix(0.0140684)
})
#> Error in dimnames(.ret) <- list(env$names, env$names): length of 'dimnames' [1] not equal to array extent
```

<sup>Created on 2024-09-13 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>