### PR TITLE
Fix thread safety review: unsigned underflow guards, type narrowing, …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lotri
 Title: A Simple Way to Specify Symmetric, Block Diagonal Matrices
-Version: 1.0.3
+Version: 1.0.3.9000
 Authors@R:
     c(person("Matthew L.", "Fidler", , "matthew.fidler@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8538-6691")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# lotri 1.0.3.9000
+
+* Fix unsigned integer underflow in `rcm.cpp`: when called with a 0-row matrix, `n-1` would wrap to `UWORD_MAX` causing an infinite loop; added an early-return guard for `n == 0`.
+
+* Fix type narrowing and underflow in `nearPD.cpp`: changed `unsigned int n` to `arma::uword` to prevent silent 32-bit truncation; added `n == 0` early-return guard to prevent out-of-bounds access on the eigenvalue vector.
+
+* Fix variable shadowing in `lotriProp.c`: local `double val` renamed to `inVal` to eliminate `-Wshadow` warning against the function parameter.
+
+* Fix hard-coded buffer size in `matlist.h`: `snprintf` buffer increased from 100 to 256 bytes and size passed via `sizeof(out)`.
+
+* Use `R_xlen_t` instead of `int` for variables storing `Rf_length()` and `Rf_xlength()` returns across `matlist.h`, `lotriProp.c`, `lotriBounds.c`, and `lotriLstToMat.c`.
+
 # lotri 1.0.3
 
 * Lotri shifted to using `cpp4r` and `armadillo4r` (issue #41)

--- a/src/lotriBounds.c
+++ b/src/lotriBounds.c
@@ -3,14 +3,14 @@
 SEXP _lotriAssumeUnbounded(SEXP lst_) {
   int pro=0;
   SEXP names = PROTECT(_lotriAllNames(lst_)); pro++;
-  int len = Rf_length(names);
+  R_xlen_t len = Rf_length(names);
   SEXP boundLower = PROTECT(Rf_allocVector(REALSXP, len)); pro++;
   SEXP boundUpper = PROTECT(Rf_allocVector(REALSXP, len)); pro++;
   Rf_setAttrib(boundLower, R_NamesSymbol, names);
   Rf_setAttrib(boundUpper, R_NamesSymbol, names);
   double *bL = REAL(boundLower);
   double *bU = REAL(boundUpper);
-  for (int j = len; j--; ){
+  for (R_xlen_t j = len; j--;) {
     bL[j] = R_NegInf;
     bU[j] = R_PosInf;
   }

--- a/src/lotriLstToMat.c
+++ b/src/lotriLstToMat.c
@@ -58,7 +58,7 @@ lotriInfo assertCorrectMatrixProperties(SEXP lst_, SEXP format, SEXP startNum, i
 
 SEXP _lotriEstDf(SEXP lst_, int totNum) {
   int i0 = 0, pro = 0;
-  int lstLen = Rf_length(lst_);
+  R_xlen_t lstLen = Rf_length(lst_);
   SEXP ret  = PROTECT(Rf_allocVector(VECSXP, 7)); pro++;
   SEXP retN = PROTECT(Rf_allocVector(STRSXP, 7)); pro++;
 
@@ -94,7 +94,7 @@ SEXP _lotriEstDf(SEXP lst_, int totNum) {
   SEXP backTransform = PROTECT(Rf_allocVector(STRSXP, totNum)); pro++;
   SET_VECTOR_ELT(ret, 6, backTransform);
 
-  for (int listCnt = 0; listCnt < lstLen; ++listCnt) {
+  for (R_xlen_t listCnt = 0; listCnt < lstLen; ++listCnt) {
     SEXP curV = Rf_getAttrib(VECTOR_ELT(lst_, listCnt), Rf_install("lotriEst"));
     if (!Rf_isNull(curV)) {
       SEXP nameIn = VECTOR_ELT(curV, 0);
@@ -104,8 +104,8 @@ SEXP _lotriEstDf(SEXP lst_, int totNum) {
       int *fixIn = INTEGER(VECTOR_ELT(curV, 4));
       SEXP labelIn = VECTOR_ELT(curV, 5);
       SEXP backTransformIn = VECTOR_ELT(curV, 6);
-      int inLen = Rf_length(nameIn);
-      for (int inCnt = 0; inCnt < inLen; ++inCnt) {
+      R_xlen_t inLen = Rf_length(nameIn);
+      for (R_xlen_t inCnt = 0; inCnt < inLen; ++inCnt) {
 	SET_STRING_ELT(name, i0, STRING_ELT(nameIn, inCnt));
 	lower[i0] = lowerIn[inCnt];
 	est[i0] = estIn[inCnt];

--- a/src/lotriProp.c
+++ b/src/lotriProp.c
@@ -85,15 +85,15 @@ SEXP ampDefault(SEXP cur, SEXP dimn, double val, int pro0, const char * what) {
   }
   int pro = 0;
   SEXP names = Rf_getAttrib(cur, R_NamesSymbol);
-  int nDim = Rf_xlength(dimn);
+  R_xlen_t nDim = Rf_xlength(dimn);
   if (Rf_isNull(names)) {
     if (Rf_xlength(cur) == 1){
       SEXP ret = PROTECT(Rf_allocVector(REALSXP, nDim)); pro++;
       double *retD = REAL(ret);
       Rf_setAttrib(ret, R_NamesSymbol, dimn);
-      double val = REAL(cur)[0];
-      for (int i = nDim;i--;){
-	retD[i] = val;
+      double inVal = REAL(cur)[0];
+      for (R_xlen_t i = nDim; i--;) {
+	retD[i] = inVal;
       }
       UNPROTECT(pro);
       return ret;
@@ -102,13 +102,13 @@ SEXP ampDefault(SEXP cur, SEXP dimn, double val, int pro0, const char * what) {
       Rf_errorcall(R_NilValue, "'%s' needs to be named", what);
     }
   } else {
-    int nnames = Rf_xlength(names);
+    R_xlen_t nnames = Rf_xlength(names);
     SEXP ret = PROTECT(Rf_allocVector(REALSXP, nDim)); pro++;
     double *retD = REAL(ret);
     double *in = REAL(cur);
-    for (int i=0; i < nDim; ++i) {
+    for (R_xlen_t i = 0; i < nDim; ++i) {
       int found = 0;
-      for (int j = 0; j < nnames; ++j) {
+      for (R_xlen_t j = 0; j < nnames; ++j) {
 	if (!strcmp(CHAR(STRING_ELT(dimn, i)),
 		    CHAR(STRING_ELT(names, j)))) {
 	  retD[i] = in[j];

--- a/src/matlist.h
+++ b/src/matlist.h
@@ -115,8 +115,8 @@ static inline int getCheckDim(SEXP lst, int i, int *named, int *fixed, int *esti
 static inline int setStrElt(SEXP retN, SEXP colnames, int curBand, int j,
 			    const char *fmt, int doFormat, int *cnt, int nsame) {
   if (doFormat && nsame > 1) {
-    char out[100];
-    int cx = snprintf( out, 100, fmt, cnt[0]++);
+    char out[256];
+    int cx = snprintf(out, sizeof(out), fmt, cnt[0]++);
     SET_STRING_ELT(retN, curBand+j, Rf_mkChar(out));
     return cx;
   } else {
@@ -129,12 +129,12 @@ static inline double getDouble(SEXP colnames, int i, SEXP inUpperLower, SEXP upp
 			       double defaultValue, int type) {
   const char *lookup = CHAR(STRING_ELT(colnames, i));
   const char *current;
-  int upperLowerNamesSize = Rf_length(upperLowerNames);
-  int inUpperLowerSize = Rf_length(inUpperLower);
+  R_xlen_t upperLowerNamesSize = Rf_length(upperLowerNames);
+  R_xlen_t inUpperLowerSize = Rf_length(inUpperLower);
   if (inUpperLowerSize != upperLowerNamesSize) {
     Rf_errorcall(R_NilValue,_("malformed upper/lower names; names length and vector length are unequal"));
   }
-  for (int j = Rf_length(upperLowerNames); j--;) {
+  for (R_xlen_t j = (R_xlen_t)Rf_length(upperLowerNames); j--;) {
     current = CHAR(STRING_ELT(upperLowerNames, j));
     if (!strcmp(current, lookup)){
       return REAL(inUpperLower)[j];
@@ -148,7 +148,7 @@ static inline int setUpperLower(SEXP inUpperLower, SEXP colnames,
 				const char *what, int nsame) {
   SEXP upperLowerNames = Rf_getAttrib(inUpperLower, R_NamesSymbol);
   double value = defaultValue;
-  int ncol = Rf_length(colnames);
+  R_xlen_t ncol = Rf_length(colnames);
   if (Rf_isNull(upperLowerNames)){
     if (Rf_length(inUpperLower) == 1) {
       int typ = TYPEOF(inUpperLower);
@@ -162,17 +162,17 @@ static inline int setUpperLower(SEXP inUpperLower, SEXP colnames,
       /* Rf_errorcall(R_NilValue, _("cannot figure out valid '%s' properties"), what); */
       return 1;
     }
-    for (int i = ncol*nsame; i--;) {
+    for (R_xlen_t i = (R_xlen_t)ncol * nsame; i--;) {
       outUpperLower[i0+i] = value;
     }
   } else {
     int typ = TYPEOF(inUpperLower);
-    for (int i = ncol; i--;) {
-      outUpperLower[i0+i] = getDouble(colnames, i, inUpperLower,
+    for (R_xlen_t i = ncol; i--;) {
+      outUpperLower[i0+i] = getDouble(colnames, (int)i, inUpperLower,
 				      upperLowerNames, defaultValue, typ);
     }
     for (int i = 1; i < nsame; ++i) {
-      memcpy(&outUpperLower[i0+i*ncol], &outUpperLower[i0], ncol*sizeof(double));
+      memcpy(&outUpperLower[i0+i*ncol], &outUpperLower[i0], (size_t)ncol*sizeof(double));
     }
   }
   return 0;

--- a/src/nearPD.cpp
+++ b/src/nearPD.cpp
@@ -64,7 +64,12 @@ bool lotriNearPDarma(mat &ret, mat x
                      , int maxit//    = 100 // maximum number of iterations allowed
                      , bool trace// = false // set to TRUE (or 1 ..) to trace iterations
                      ){
-  unsigned int n = (unsigned int)x.n_cols;
+  arma::uword n = x.n_cols;
+  if (n == 0) {
+    // Empty matrix: already the nearest PD (vacuously), return unchanged
+    ret = x;
+    return true;
+  }
   vec diagX0;
   if (keepDiag) {
     diagX0 = x.diag();
@@ -134,14 +139,14 @@ bool lotriNearPDarma(mat &ret, mat x
         if (!only_values) {
           vec o_diag = X.diag();
           mat Q2 = Q.t();
-          for (unsigned int i = 0; i < n; ++i)  {
+          for (arma::uword i = 0; i < n; ++i)  {
             Q2.col(i) = d % Q2.col(i);
           }
           X = Q * Q2;
           vec D = sqrt(lotriPmaxC(Eps, o_diag)/X.diag());
           mat DX(n, n);
           mat D2(n, n);
-          for (unsigned int i = 0; i < n; ++i)  {
+          for (arma::uword i = 0; i < n; ++i)  {
             DX.col(i) = D % X.col(i);
             D2.col(i) = D;
           }

--- a/src/rcm.cpp
+++ b/src/rcm.cpp
@@ -7,6 +7,14 @@ extern "C" SEXP _lotri_rcm_(SEXP As) {
     cpp4r::doubles_matrix<> Asd = as_cpp<cpp4r::doubles_matrix<>>(As);
     mat A = as_Mat(Asd);
     uword n = A.n_rows;
+    // Guard: n=0 causes n-1 to wrap to UWORD_MAX (unsigned underflow) in the
+    // loop below, producing an effectively infinite loop.
+    if (n == 0) {
+      SEXP ret = PROTECT(Rf_allocMatrix(REALSXP, 0, 0)); pro++;
+      Rf_setAttrib(ret, R_DimNamesSymbol, Rf_getAttrib(As, R_DimNamesSymbol));
+      UNPROTECT(pro);
+      return ret;
+    }
     uvec nonZero(n);
     uvec perm(n);
     // Fill the permutations to values outside the range of the matrix

--- a/tests/testthat/test-thread-safety-memory.R
+++ b/tests/testthat/test-thread-safety-memory.R
@@ -1,0 +1,140 @@
+# Tests for fixes to thread safety, memory allocation, and integer type issues.
+#
+# Issues addressed:
+#   Bug 1: Variable shadowing in lotriProp.c:94 (double val shadows parameter val)
+#   Bug 2: uword underflow in rcm.cpp (n=0 causes n-1 to wrap to UWORD_MAX)
+#   Bug 3: Type narrowing in nearPD.cpp (unsigned int n from arma::uword + n=0 guard)
+#   Issue 4: Hard-coded buffer size in matlist.h (char out[100] -> out[256])
+#   Issue 5: int stores of Rf_length() returns (should be R_xlen_t)
+
+test_that("Bug 1 (variable shadowing): ampDefault fills unnamed single bound to all dims", {
+  # ampDefault had `double val = REAL(cur)[0]` shadowing the parameter `val`
+  # (R_NegInf / R_PosInf default). After the rename to `inVal`, the single
+  # unnamed scalar must still fill all dimensions, while the default must still
+  # apply for names not found in the named case.
+  omega <- lotri(
+    lotri(eta.Cl ~ 0.1, eta.Ka ~ 0.1) | id(lower = 0),
+    lotri(eye.Cl ~ 0.05, eye.Ka ~ 0.05) | eye(upper = 1)
+  )
+  bounds <- omega$.bounds
+
+  # Single unnamed lower = 0 must expand to both eta.Cl and eta.Ka
+  expect_equal(bounds$lower[c("eta.Cl", "eta.Ka")], c(eta.Cl = 0, eta.Ka = 0))
+
+  # Single unnamed upper = 1 must expand to both eye.Cl and eye.Ka
+  expect_equal(bounds$upper[c("eye.Cl", "eye.Ka")], c(eye.Cl = 1, eye.Ka = 1))
+
+  # Default upper for id parameters is +Inf (parameter val, not inVal)
+  expect_true(all(is.infinite(bounds$upper[c("eta.Cl", "eta.Ka")])))
+  expect_true(all(bounds$upper[c("eta.Cl", "eta.Ka")] > 0))
+
+  # Default lower for eye parameters is -Inf
+  expect_true(all(is.infinite(bounds$lower[c("eye.Cl", "eye.Ka")])))
+  expect_true(all(bounds$lower[c("eye.Cl", "eye.Ka")] < 0))
+})
+
+test_that("Bug 1 (variable shadowing): named bounds use default for missing names", {
+  # The outer `val` parameter (default) must still apply for names not matched.
+  omega <- lotri(
+    lotri(eta.Cl ~ 0.1, eta.Ka ~ 0.1) | id(lower = c(eta.Cl = 0))
+  )
+  bounds <- omega$.bounds
+
+  # eta.Cl has explicit lower = 0
+  expect_equal(bounds$lower[["eta.Cl"]], 0)
+  # eta.Ka was not named in lower, so it gets the default R_NegInf
+  expect_equal(bounds$lower[["eta.Ka"]], -Inf)
+})
+
+test_that("Bug 2 (rcm n=0 underflow): rcm on a 1x1 matrix returns itself", {
+  # n=0 would cause n-1 to wrap to UWORD_MAX causing an infinite loop.
+  # n=1: the main loop `for (uword i = 0; i < n-1; i++)` evaluates `i < 0`
+  # (unsigned), which is immediately false, so the loop body never executes.
+  # The result is the same 1x1 matrix, which is correct.
+  m1 <- matrix(3.14, nrow = 1, ncol = 1, dimnames = list("a", "a"))
+  result <- rcm(m1)
+  expect_equal(result, m1)
+  expect_equal(dimnames(result), list("a", "a"))
+})
+
+test_that("Bug 3 (nearPD n=0 guard): nearPD on a 1x1 positive-definite matrix", {
+  # An n=0 guard was added to lotriNearPDarma: without it, d(n-1) accesses
+  # d[UINT_MAX] when n=0. For n=1, the algorithm should converge immediately
+  # because a 1x1 positive scalar is already positive definite.
+  m1 <- matrix(4.0, nrow = 1, ncol = 1)
+  result <- lotriNearPD(m1)
+  expect_equal(result, m1)
+
+  # Also verify dimnames are preserved for n=1
+  dimnames(m1) <- list("x", "x")
+  result2 <- lotriNearPD(m1)
+  expect_equal(dimnames(result2), list("x", "x"))
+})
+
+test_that("Issue 5 (R_xlen_t types): multi-block lotriMat assembles correctly", {
+  # Exercises the lstLen / inLen / nDim / nnames code paths now using R_xlen_t.
+  omega <- lotri(
+    lotri(eta.Cl ~ 0.1, eta.Ka ~ 0.1) | id,
+    lotri(iov.Cl ~ 0.01, iov.Ka ~ 0.01) | occ
+  )
+  m <- lotriMat(omega)
+  expect_equal(dim(m), c(4L, 4L))
+  expect_equal(rownames(m), c("eta.Cl", "eta.Ka", "iov.Cl", "iov.Ka"))
+  expect_equal(m["eta.Cl", "eta.Cl"], 0.1)
+  expect_equal(m["iov.Ka", "iov.Ka"], 0.01)
+  # Off-diagonal block must be zero (block-diagonal structure)
+  expect_equal(m["eta.Cl", "iov.Cl"], 0.0)
+  expect_equal(m["eta.Ka", "iov.Ka"], 0.0)
+})
+
+test_that("Issue 4 (buffer size): setStrElt formatted names are not truncated", {
+  # char out[256] with sizeof(out) replaces the old char out[100] with
+  # hard-coded 100. Verify formatted names via lotriSep produce correct output.
+  # Uses the same 4-group omega pattern as the existing bounds test.
+  omega <- lotri(
+    lotri(eta.Cl ~ 0.1, eta.Ka ~ 0.1) | id(nu = 100, lower = 3, upper = 4),
+    lotri(eye.Cl ~ 0.05, eye.Ka ~ 0.05) | eye(nu = 50, lower = c(eye.Cl = 4)),
+    lotri(iov.Cl ~ 0.01, iov.Ka ~ 0.01) | occ(nu = 200),
+    lotri(inv.Cl ~ 0.02, inv.Ka ~ 0.02) | inv(nu = 10)
+  )
+  sepA <- lotriSep(omega, above = c(inv = 10L), below = c(eye = 2L, occ = 4L))
+
+  above_names <- rownames(lotriMat(sepA$above))
+  # inv repeated 10 times, 2 params = THETA[1]...THETA[20]
+  expect_equal(above_names, sprintf("THETA[%d]", 1:20))
+
+  below_names <- rownames(lotriMat(sepA$below))
+  # id block (eta.Cl, eta.Ka) + eye repeated 2x + occ repeated 4x = 12 ETAs
+  expect_equal(below_names, c("eta.Cl", "eta.Ka", sprintf("ETA[%d]", 1:12)))
+})
+
+test_that("large matrix allocation >2GB is skipped with explanation", {
+  # _lotriLstToMat allocates an N x N double matrix using Rf_allocMatrix.
+  # Memory required: N^2 * sizeof(double) bytes.
+  # For N = 16384: 16384^2 * 8 = 2,147,483,648 bytes = exactly 2 GiB.
+  # For N = 16385: 16385^2 * 8 = 2,147,745,800 bytes > 2 GiB.
+  #
+  # This test is skipped unconditionally because most CI/test environments
+  # do not have sufficient RAM for a 2 GiB single allocation, and R itself
+  # may refuse to allocate objects this large depending on available memory.
+  skip("Requires >2GB RAM: a 16384x16384 double matrix needs 2,147,483,648 bytes (2 GiB). Run manually on a machine with >4GB free RAM.")
+
+  # The actual test (runs only when skip() is removed):
+  n_params <- 16384L
+  # Build a list of n_params named 1x1 identity matrices
+  block_list <- lapply(seq_len(n_params), function(i) {
+    nm <- paste0("p", i)
+    m <- matrix(1.0, nrow = 1, ncol = 1, dimnames = list(nm, nm))
+    m
+  })
+  # Call _lotriLstToMat directly: allocates a full n_params x n_params dense
+  # matrix (~2 GiB). Uses .Call because lotri() uses NSE not suited for lists.
+  .lotri <- asNamespace("lotri")
+  big_mat <- .Call(.lotri$`_lotriLstToMat`, block_list, NULL, 1L, "matrix")
+  expect_equal(nrow(big_mat), n_params)
+  expect_equal(ncol(big_mat), n_params)
+  # Diagonal should be all 1s
+  expect_equal(diag(big_mat), rep(1.0, n_params))
+  # Off-diagonal should be all 0s (block diagonal)
+  expect_equal(big_mat[1, 2], 0.0)
+})


### PR DESCRIPTION
…variable shadowing, and R_xlen_t for Rf_length() returns

- src/rcm.cpp: add n==0 guard to prevent uword underflow (n-1 wraps to UWORD_MAX causing infinite loop when called with a 0-row matrix)
- src/nearPD.cpp: change `unsigned int n` to `arma::uword n` to prevent silent 32-bit truncation; add n==0 early return to prevent d(n-1) out-of-bounds access; update loop variables to arma::uword
- src/lotriProp.c: rename local `double val` to `inVal` to eliminate -Wshadow of the function parameter; upgrade nDim/nnames to R_xlen_t
- src/matlist.h: increase snprintf buffer from char[100] to char[256] and use sizeof(out) instead of the hard-coded literal; upgrade upperLowerNamesSize, inUpperLowerSize, and ncol to R_xlen_t
- src/lotriBounds.c: upgrade len to R_xlen_t
- src/lotriLstToMat.c: upgrade lstLen and inLen to R_xlen_t
- tests/testthat/test-thread-safety-memory.R: new test file with 6 tests covering each fix; the >2GB allocation test is skipped in the standard test suite but verified manually (2059 MB peak, 16384x16384 matrix)