### PR TITLE
Fix lotriNearPD(only.values=TRUE) abort on already-PD input

### DIFF
--- a/src/nearPD.cpp
+++ b/src/nearPD.cpp
@@ -152,15 +152,20 @@ bool lotriNearPDarma(mat &ret, mat x
           }
           X = DX % D2;
         }
-        if (only_values) {
-          ret = d;
-          return true;
-        }
-
         // unneeded(?!): X <- (X + t(X))/2
         if (keepDiag) {
           X.diag()= diagX0;
         }
+      }
+      if (only_values) {
+        // Return the (posdefified) eigenvalues whether or not any eigenvalue
+        // actually needed clamping.  Previously this lived inside the
+        // `d(n-1) < Eps` branch, so an already-positive-definite input skipped
+        // it and fell through to `ret = X` below -- assigning an n x n matrix
+        // into the length-n `ret` vector alias, which aborts with
+        // "unknown c++ error".
+        ret = d;
+        return true;
       }
     } //end from posdefify(sfsmisc)
   }

--- a/tests/testthat/test-nearPD.R
+++ b/tests/testthat/test-nearPD.R
@@ -24,6 +24,22 @@ test_that("lotriNearPD on 0x0 matrix returns 0x0 matrix", {
   expect_equal(dim(r), c(0L, 0L))
 })
 
+test_that("lotriNearPD(only.values=TRUE) works on already positive-definite input", {
+  ## Before the fix the only_values path only assigned the eigenvalues inside
+  ## the d(n-1) < Eps clamping branch; an already-PD input skipped it and fell
+  ## through to `ret = X` -- an n x n matrix assigned into the length-n result
+  ## alias -- aborting with "unknown c++ error".
+  pd <- matrix(c(4, 1, 1, 3), 2, 2)
+  expect_equal(sort(lotriNearPD(pd, only.values = TRUE), decreasing = TRUE),
+               sort(eigen(pd, only.values = TRUE)$values, decreasing = TRUE))
+  pd3 <- matrix(c(10, 3, 2, 3, 8, 1, 2, 1, 6), 3, 3)
+  expect_equal(sort(lotriNearPD(pd3, only.values = TRUE), decreasing = TRUE),
+               sort(eigen(pd3, only.values = TRUE)$values, decreasing = TRUE))
+  ## the non-PD path (clamps small eigenvalues) is unchanged
+  npd <- matrix(c(1, 2, 2, 1), 2, 2)
+  expect_no_error(lotriNearPD(npd, only.values = TRUE))
+})
+
 test_that("test nearPD with same functions as Matrix", {
   # https://github.com/cran/Matrix/blob/65c37738919156f6bbb682a1d8198d715a82a19f/tests/dpo-test.R#L69-L136
   # Testing nearPD() --- this is partly in  ../man/nearPD.Rd :


### PR DESCRIPTION
In the only_values path the result vector aliases a strict length-n buffer. ret = d (eigenvalues) only ran inside the d(n-1) < Eps clamping branch, so an already-PD input skipped it and fell through to ret = X — assigning an n×n matrix into the length-n alias, which Armadillo rejects ("unknown c++ error").

Reproducer: lotriNearPD(matrix(c(4,1,1,3),2,2), only.values=TRUE).
Fix: move the only_values return out of the clamp branch. Verified: now returns 4.618034, 2.381966 (matches eigen()); non-PD clamping and the full-matrix path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)